### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/empty_view.xml
+++ b/app/src/main/res/layout/empty_view.xml
@@ -31,7 +31,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center|center_vertical"
-                android:textColor="?attr/emptyViewColor"
+                android:textColor="#707070"
                 android:textSize="18sp" />
 
             <TextView
@@ -40,7 +40,7 @@
                 android:layout_height="wrap_content"
                 android:gravity="center|center_vertical"
                 android:text="¯\\_(ツ)_/¯"
-                android:textColor="?attr/emptyViewColor"
+                android:textColor="#707070"
                 android:textSize="18sp" />
 
             <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
The original text color of the component is '#818181', and the contrast between the text color ('#818181') and the background color ('#F4F4F4') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#707070') are as follows:
![image](https://user-images.githubusercontent.com/101503193/184941537-edf9fdc4-a4e3-43b7-a08f-ce3717ffd157.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.